### PR TITLE
fix: disable color output when fetching history

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2133,6 +2133,7 @@ bool RunGetHistory(const FString& InPathToGitBinary, const FString& InRepository
 	{
 		TArray<FString> Results;
 		TArray<FString> Parameters;
+		Parameters.Add(TEXT("--no-color"));
 		Parameters.Add(TEXT("--follow")); // follow file renames
 		Parameters.Add(TEXT("--date=raw"));
 		Parameters.Add(TEXT("--name-status")); // relative filename at this revision, preceded by a status character


### PR DESCRIPTION
I have set `color.ui` to `always` globally.

At https://github.com/ProjectBorealis/UEGitPlugin/blob/91f73de2cb47a1e83ffb735c912820ddcf0fe78c/Source/GitSourceControl/Private/GitSourceControlUtils.cpp#L2034, it becomes `\x1b[33mcommit\x1b[m`, which invalidates the first line of the commit message.

Adding `Parameters.Add(TEXT("--no-color"));` at https://github.com/ProjectBorealis/UEGitPlugin/blob/91f73de2cb47a1e83ffb735c912820ddcf0fe78c/Source/GitSourceControl/Private/GitSourceControlUtils.cpp#L2135 fixes it.

This may fix the issue at https://github.com/ProjectBorealis/UEGitPlugin/issues/187 (I'm not sure if it's the same problem as theirs).