### PR TITLE
Grant execute permission to git lfs on mac and linux

### DIFF
--- a/GitSourceControl.uplugin
+++ b/GitSourceControl.uplugin
@@ -19,5 +19,15 @@
 			"Type": "UncookedOnly",
 			"LoadingPhase": "Default"
 		}
-	]
+	],
+	"PreBuildSteps":
+	{
+		"Mac": [
+			"chmod +x \"$(PluginDir)/git-lfs-mac-amd64\"",
+			"chmod +x \"$(PluginDir)/git-lfs-mac-arm64\""
+		],
+		"Linux": [
+			"chmod +x \"$(PluginDir)/git-lfs\""
+		]
+	},
 }


### PR DESCRIPTION
By default the git lfs binary files don't have the execute permission which makes the git lfs calls fail.

We have several team members working on Mac and they need to manually grant the git lfs binary execute permission, but this can be done automatically via the build.