### PR TITLE
Fix for ambiguous short commit hash errors when checking file history

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2163,7 +2163,7 @@ bool RunGetHistory(const FString& InPathToGitBinary, const FString& InRepository
 		TArray<FString> Results;
 		TArray<FString> Parameters;
 		Parameters.Add(TEXT("--long")); // Show object size of blob (file) entries.
-		Parameters.Add(Revision->GetRevision());
+		Parameters.Add(Revision->CommitId);
 		TArray<FString> Files;
 		Files.Add(*Revision->GetFilename());
 		bResults &= RunCommand(TEXT("ls-tree"), InPathToGitBinary, InRepositoryRoot, Parameters, Files, Results, OutErrorMessages);


### PR DESCRIPTION
If the commit short ID was ambiguous, the plugin would throw an error and fail to find the history. This uses the full commit ID.

<img width="952" height="386" alt="image" src="https://github.com/user-attachments/assets/328678fc-462c-4aee-9f8f-78a0f1ac4213" />
